### PR TITLE
v0.0.16 - Rework kills reachable script in browser

### DIFF
--- a/update.php
+++ b/update.php
@@ -1,5 +1,5 @@
 <?php
-if(!defined('STDIN')) {
+if (!defined('STDIN')) {
     header("HTTP/1.0 404 Not Found", true, 404);
     die();
 }

--- a/update.php
+++ b/update.php
@@ -1,4 +1,9 @@
 <?php
+if(!defined('STDIN')) {
+    header("HTTP/1.0 404 Not Found", true, 404);
+    die();
+}
+
 if (file_exists(getcwd() . '/manifest.json')) {
     define("current_manifest", json_decode(file_get_contents(getcwd() . '/manifest.json'), true));
     define("current_version", current_manifest['version']);

--- a/v1/deploy.php
+++ b/v1/deploy.php
@@ -10,6 +10,11 @@
  * @link   https://github.com/ruvenss/pmsrapi
  * IF YOU ADD YOUR CODE HERE IT WILL BE OVERWRITTEN ON THE NEXT UPDATE
  */
+
+if (!defined('STDIN')) {
+    header("HTTP/1.0 404 Not Found", true, 404);
+    die();
+}
 if (PHP_OS_FAMILY !== 'Linux') {
     echo "🔴 This script only works on Ubuntu 22, and >24\n";
     die();


### PR DESCRIPTION
I added a check at the top of the script that should kill all access from a HTTP request and forward to a 404 status code.