### PR TITLE
v0.0.16 - Reworked http_response

### DIFF
--- a/v1/index.php
+++ b/v1/index.php
@@ -79,7 +79,7 @@ function ms_universe_wrap_up($http_code,$response=null)
     header("X-Powered-By: PMSRAPI");
     header("MicroService: " . ms_name);
     header("MicroService-Version: " . ms_version);
-    array_map(function($key, $value) { header("$key: $value"); }, array_keys(ms_http_headers), array_values(ms_http_headers));
+    array_walk(ms_http_headers, function ($value, $key) { header("$key: $value"); });
     if (isset($response)) {
         echo $response;
     }

--- a/v1/index.php
+++ b/v1/index.php
@@ -73,29 +73,25 @@ if ($_SERVER['CONTENT_TYPE'] === 'application/json') {
 } else {
     http_response(400, ["error" => "Bad Request only application/json is allowed"]);
 }
-function http_response($http_code = 200, $data = null)
+function ms_universe_wrap_up($http_code,$response=null)
 {
-    $response = ms_restful_responses;
-    $http_headers = ms_http_headers;
-    $success = false;
-    if ($http_code == 200) {
-        $success = true;
-    }
-    header("HTTP/1.1 $http_code $response[$http_code]");
+    header("HTTP/1.1 $http_code " . ms_restful_responses[$http_code]);
     header("X-Powered-By: PMSRAPI");
-    foreach ($http_headers as $key => $value) {
-        header("$key: $value");
-    }
     header("MicroService: " . ms_name);
     header("MicroService-Version: " . ms_version);
-    if ($data) {
-        $response = ["success" => $success, "data" => $data];
-        echo json_encode($response);
+    array_map(function($key, $value) { header("$key: $value"); }, array_keys(ms_http_headers), array_values(ms_http_headers));
+    if (isset($response)) {
+        echo $response;
     }
     if (defined("dbconn")) {
         dbconn->close();
     }
     die();
+}
+function http_response($http_code = 200, $data = null)
+{
+    $response = ["success" => $http_code == 200, "data" => $data];
+    ms_universe_wrap_up($http_code, json_encode($response));
 }
 function http_rest($node, $function, $payload, $parameters, $method = "GET")
 {


### PR DESCRIPTION
The current implementation of the API interaction in the library has a hardcoded way of handling the results of CRUD requests. This approach, while functional, is not flexible enough to cater to a broader range of use cases. Not every developer might want to process the results in the same manner or may need to perform additional steps when handling the result of an API request.

To improve the library's versatility and make it more adaptable to different scenarios, I propose that we make the result handling more generic. Instead of having a fixed flow, the library could allow users to define their own result. 

This change would make the library more flexible, allowing users to integrate it more seamlessly into their unique environments, including mine.