### PR TITLE
fix(deploy): added more cli workers

### DIFF
--- a/v1/deploy.php
+++ b/v1/deploy.php
@@ -42,6 +42,7 @@ Description=' . ms_description . '
 After=network.target
 
 [Service]
+Environment=PHP_CLI_SERVER_WORKERS=20
 ExecStart=/usr/bin/php -S ' . ms_secrets['http']['host'] . ':' . ms_secrets['http']['port'] . ' -t ' . project_path . '
 Restart=always
 User=root


### PR DESCRIPTION
The PHP development server requires an environment variable to increase the amount of threads it allows. Each thread/process can only handle a single open connection.