### PR TITLE
v0.0.27 - Apache not forwarding auth header

### DIFF
--- a/v2/.htaccess
+++ b/v2/.htaccess
@@ -2,9 +2,18 @@
 # Forward every /v2/... request that is not a real file to the front controller.
 # nginx equivalent is documented in v2/README.md.
 
+<IfVersion >= 2.4.13>
+    CGIPassAuth On
+</IfVersion>
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteBase /v2/
+
+    <IfVersion < 2.4.13>
+        RewriteCond %{HTTP:Authorization} ^(.*)
+        RewriteRule .* - [E=HTTP_AUTHORIZATION:%1]
+    </IfVersion>
 
     # Serve existing files/dirs directly (static assets).
     RewriteCond %{REQUEST_FILENAME} -f [OR]


### PR DESCRIPTION
It turns out the .htaccess strips the Authorization header causing the framework to not be able to read the `$_SERVER['HTTP_AUTHORIZATION']` value.

Added extra checks for the version to make sure it works for everyone.

I've verified it to be working (and required for us) on `Ubuntu 24.04.2 LTS` with `Apache/2.4.58` and `PHP/8.3`.

If you don't have it you get:
```json
{
    "success": false,
    "error": {
        "code": "unauthorized",
        "message": "Missing or malformed Authorization: Bearer header"
    }
}
```