### PR TITLE
v0.0.27 - Variable version

### DIFF
--- a/v2/src/Cluster/ServiceClient.php
+++ b/v2/src/Cluster/ServiceClient.php
@@ -174,7 +174,7 @@ final class ServiceClient
             (string) ($spec['path'] ?? '/'),
         );
 
-        $version = (int) ($spec['version'] ?? 2);
+        $version = (int) ($node['version'] ?? 2);
         $scheme = ($node['ssl'] ?? true) ? 'https' : 'http';
         $url = $scheme . '://' . $node['ip'] . ':' . $node['port'] . '/v' . $version . '/' . ltrim($path, '/');
 

--- a/v2/src/Cluster/ServiceClient.php
+++ b/v2/src/Cluster/ServiceClient.php
@@ -174,8 +174,9 @@ final class ServiceClient
             (string) ($spec['path'] ?? '/'),
         );
 
+        $version = (int) ($spec['version'] ?? 2);
         $scheme = ($node['ssl'] ?? true) ? 'https' : 'http';
-        $url = $scheme . '://' . $node['ip'] . ':' . $node['port'] . '/v2' . '/' . ltrim($path, '/');
+        $url = $scheme . '://' . $node['ip'] . ':' . $node['port'] . '/v' . $version . '/' . ltrim($path, '/');
 
         $body = null;
         if ($method === 'GET') {


### PR DESCRIPTION
The current v2 doesn't allow the user to make api calls to an earlier version of the framework causing a lot of tech debt would this feature not be allowed. It's completely optional as it defaults to `v2` if not filled in the config.